### PR TITLE
remove as tests from the report

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,18 +7,6 @@
     },
     {
       "baseUrl": "http://narayanaci1.eng.hst.ams2.redhat.com",
-      "name": "narayana-as-tests"
-    },
-    {
-      "baseUrl": "http://narayanaci1.eng.hst.ams2.redhat.com",
-      "name": "narayana-AS800"
-    },
-    {
-      "baseUrl": "http://narayanaci1.eng.hst.ams2.redhat.com",
-      "name": "narayana-AS800-windows"
-    },
-    {
-      "baseUrl": "http://narayanaci1.eng.hst.ams2.redhat.com",
       "name": "narayana-catelyn"
     },
     {


### PR DESCRIPTION
removal of AS800 and as-tests from the report as discussed in the weekly narayana team meeting on 25 Jan 2021