### PR TITLE
uglify-js updated to 3.15.4 to fix CVE-2021-43138

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "q": "^1.4.1",
     "through2": "^2.0.0",
     "through2-filter": "^2.0.0",
-    "uglify-js": "2.6.0",
+    "uglify-js": ">=3.15.4",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
uglify-js updated to 3.15.4 to fix CVE-2021-43138