### PR TITLE
Include all jobs in ci report

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,6 +47,18 @@
     {
       "baseUrl": "${ENV.JENKINS_URL}",
       "name": "release-narayana-quickstarts"
+    },
+    {
+      "baseUrl": "${ENV.JENKINS_URL}",
+      "name": "release-narayana"
+    },
+    {
+      "baseUrl": "${ENV.JENKINS_URL}",
+      "name": "release-narayana-performance-comparison"
+    },
+    {
+      "baseUrl": "${ENV.JENKINS_URL}",
+      "name": "narayana-performance"
     }
   ]
 }


### PR DESCRIPTION
I think we should include all the jobs in the report generator. What about including the btny-pull jobs too?